### PR TITLE
Enhanced edit form layout - add fields to Root.Main

### DIFF
--- a/code/dataobjects/UserTemplate.php
+++ b/code/dataobjects/UserTemplate.php
@@ -47,7 +47,7 @@ class UserTemplate extends DataObject {
 
 		$templates = $this->fileBasedTemplates();
 		if (count($templates)) {
-			$fields->push($dd = new DropdownField('ContentFile', _t('UserTemplatesExtension.CONTENT_FILE', 'File containing template'), $templates));
+			$fields->addFieldToTab('Root.Main', $dd = new DropdownField('ContentFile', _t('UserTemplatesExtension.CONTENT_FILE', 'File containing template'), $templates));
 			$dd->setRightTitle('If selected, any Content set above will be ignored');
 		} else {
 			$fields->removeByName('ContentFile');
@@ -56,13 +56,13 @@ class UserTemplate extends DataObject {
 		$templates = DataList::create('UserTemplate')->filter(array('ID:Negation' => $this->ID));
 		if ($templates->count()) {
 			$templates = $templates->map();
-			$fields->push($kv = new KeyValueField('ActionTemplates', _t('UserTemplates.ACTION_TEMPLATES', 'Action specific templates'), array(), $templates));
+			$fields->addFieldToTab('Root.Main', $kv = new KeyValueField('ActionTemplates', _t('UserTemplates.ACTION_TEMPLATES', 'Action specific templates'), array(), $templates));
 			$kv->setRightTitle(_t('UserTemplates.ACTION_TEMPLATES_HELP', 'Specify an action name and select another user defined template to handle a specific action. Only used for Layout templates'));
 		}
 		
 		
-		$fields->push($cssFiles);
-		$fields->push($jsFiles);
+		$fields->addFieldToTab('Root.Main', $cssFiles);
+		$fields->addFieldToTab('Root.Main', $jsFiles);
 
 		return $fields;
 	}


### PR DESCRIPTION
Replaced ->push() with ->addFieldToTab('Root.Main', ...)

Form field labels all line up along the left side now.

![Screen Shot 2013-02-13 at 3 23 30 PM](https://f.cloud.github.com/assets/341209/154648/08e6dd96-7624-11e2-88ea-99a8f14461dc.png)

Note: I'm using a Codemirror HTML field in the screenshot which is not included in this module or pull request.
