### PR TITLE
FIX case of :not modifier

### DIFF
--- a/code/dataobjects/UserTemplate.php
+++ b/code/dataobjects/UserTemplate.php
@@ -62,7 +62,7 @@ class UserTemplate extends DataObject {
 DOC;
 		$strict->setRightTitle(_t('UserTemplates.STRICT_HELP', $text));
 		
-		$templates = DataList::create('UserTemplate')->filter(array('ID:Not' => $this->ID));
+		$templates = DataList::create('UserTemplate')->filter(array('ID:not' => $this->ID));
 		if ($templates->count()) {
 			$templates = $templates->map();
 			$fields->addFieldToTab('Root.Main', $kv = new KeyValueField('ActionTemplates', _t('UserTemplates.ACTION_TEMPLATES', 'Action specific templates'), array(), $templates));


### PR DESCRIPTION
Fixes an exception I was getting on OS X, PHP 5.5.5

[User Error] Uncaught InvalidArgumentException: ExactMatchFilter does not accept Not as modifiers
