### PR TITLE
FIX, without S3 the includes aren't resolving

### DIFF
--- a/code/dataobjects/UserTemplate.php
+++ b/code/dataobjects/UserTemplate.php
@@ -172,14 +172,14 @@ DOC;
 		$obj = $this->CustomCSSFiles();
 		if ($obj) {
 			foreach ($obj as $file) {
-				Requirements::css($file->getURL());
+				Requirements::css(Director::absoluteURL($file->getURL()));
 			}
 		}
 
 		$obj = $this->CustomJSFiles();
 		if ($obj) {
 			foreach ($obj as $file) {
-				Requirements::javascript($file->getURL());
+				Requirements::javascript(Director::absoluteURL($file->getURL()));
 			}
 		}
 


### PR DESCRIPTION
correctly.

- They're being resolved as `/assets/file.css`.
- They should be resolved as `assets/file.css`.
- This continues to support S3, since it doesn't change an S3 URL.