### PR TITLE
fix(UserTemplate.php): Fix cache path for SS4

### DIFF
--- a/src/UserTemplate.php
+++ b/src/UserTemplate.php
@@ -182,7 +182,7 @@ DOC;
 	 * @return string
 	 */
 	protected function getCacheFilename() {
-		$dir = BASE_PATH . '/usertemplates/template-cache/' . $this->Use . '/';
+		$dir = TEMP_PATH . '/usertemplates/template-cache/' . $this->Use . '/';
 		Filesystem::makeFolder($dir);
         $dateStamp = strtotime($this->LastEdited);
 		$file = $dir . '/' . $this->Title . '-' . $dateStamp . '.ss';


### PR DESCRIPTION
Replace 'BASE_PATH' with 'TEMP_PATH'.

Resolves https://github.com/nyeholt/silverstripe-usertemplates/issues/20